### PR TITLE
Linting

### DIFF
--- a/ansible/roles/jibri/handlers/main.yml
+++ b/ansible/roles/jibri/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart jibri
-  service: 
+  service:
     name: jibri
     state: restarted

--- a/ansible/roles/jibri/tasks/install.yml
+++ b/ansible/roles/jibri/tasks/install.yml
@@ -62,7 +62,7 @@
     state: present
 
 - name: Get current google release
-  uri: 
+  uri:
     url: http://chromedriver.storage.googleapis.com/LATEST_RELEASE
     return_content: yes
   register: googleversion
@@ -86,10 +86,10 @@
     name: "{{ item }}"
     state: present
   loop:
-    - default-jre-headless 
+    - default-jre-headless
     - ffmpeg
     - curl
-    - alsa-utils 
+    - alsa-utils
     - icewm
     - xdotool
     - xserver-xorg-input-void
@@ -104,7 +104,7 @@
   apt:
     name: "{{item}}"
     state: present
-  loop: 
+  loop:
     - openjdk-8-jdk
     - openjdk-8-jdk-headless
     - openjdk-8-jre
@@ -121,7 +121,7 @@
     state: present
 
 - name: Install jibri
-  apt: 
+  apt:
     name: jibri
     state: present
     update_cache: yes

--- a/ansible/roles/jibri/tasks/main.yml
+++ b/ansible/roles/jibri/tasks/main.yml
@@ -7,7 +7,7 @@
     remote_src: true
 
 - name: Copy local .jar file
-  copy: 
+  copy:
     src: jibri-8.0-SNAPSHOT-jar-with-dependencies.jar
     dest: /opt/jitsi/jibri/jibri.jar
     mode: '0644'

--- a/ansible/roles/jitsi/handlers/main.yml
+++ b/ansible/roles/jitsi/handlers/main.yml
@@ -21,6 +21,7 @@
   when: not videobridge_only
 
 - name: reload systemctl
-  shell: systemctl daemon-reload
+  systemd:
+    daemon_reload: yes
   tags:
     - jitsi

--- a/ansible/roles/shib/tasks/main.yml
+++ b/ansible/roles/shib/tasks/main.yml
@@ -37,6 +37,7 @@
     - shib
   command: openssl x509 -in /etc/shibboleth/sp-cert.pem -fingerprint -sha1 -noout
   register: fingerprint
+  changed_when: false
 
 - name: shib | write supervisor config
   become: yes


### PR DESCRIPTION
just some minor fixes for problems reported by ansible-lint

there are more but
- if there is a specific reason for using latest in some apt tasks
- I don't know your policy for task naming
- if the site24x7 installation tasks create some file (idempotence) or need some ENV (command instead of shell)